### PR TITLE
refactor: use getLatestRelease API instead of listReleases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: build
+name: test
 
 on:
   pull_request:
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  test:
     name: 👷 Test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/dist/index.js
+++ b/dist/index.js
@@ -32953,18 +32953,16 @@ async function getVersion() {
  * @example "v0.1.0"
  */
 async function getLatestVersion() {
-    const releaseResponse = await octokit.rest.repos.listReleases({
+    const releaseResponse = await octokit.rest.repos.getLatestRelease({
         owner: "spacelift-io",
         repo: "spacectl",
     });
-    const releaseList = releaseResponse.data;
-    if (!releaseList?.length) {
+    if (!releaseResponse.data?.tag_name) {
         const errMsg = "Could not find any releases for Spacectl. GitHub outage perhaps? https://www.githubstatus.com/";
         core.setFailed(errMsg);
         throw new Error(errMsg);
     }
-    const filteredReleases = releaseList.filter((release) => !release.draft && !release.prerelease);
-    return filteredReleases[0].tag_name;
+    return releaseResponse.data.tag_name;
 }
 /**
  * Copy-pasta of:

--- a/src/install.ts
+++ b/src/install.ts
@@ -89,21 +89,18 @@ async function getVersion(): Promise<string> {
  * @example "v0.1.0"
  */
 async function getLatestVersion(): Promise<string> {
-  const releaseResponse = await octokit.rest.repos.listReleases({
+  const releaseResponse = await octokit.rest.repos.getLatestRelease({
     owner: "spacelift-io",
     repo: "spacectl",
   });
-  const releaseList = releaseResponse.data;
 
-  if (!releaseList?.length) {
+  if (!releaseResponse.data?.tag_name) {
     const errMsg = "Could not find any releases for Spacectl. GitHub outage perhaps? https://www.githubstatus.com/";
     core.setFailed(errMsg);
     throw new Error(errMsg);
   }
 
-  const filteredReleases = releaseList.filter((release) => !release.draft && !release.prerelease);
-
-  return filteredReleases[0].tag_name;
+  return releaseResponse.data.tag_name;
 }
 
 /**


### PR DESCRIPTION
Switched to the dedicated endpoint which returns exactly what we need without fetching and filtering the entire release list.

Also renamed the CI workflow from build to test to better reflect its purpose.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Refactor latest version retrieval**
> 
> - Replace `octokit.rest.repos.listReleases` + filtering with `octokit.rest.repos.getLatestRelease` in `src/install.ts` (and regenerated `dist/index.js`), simplifying logic to return `tag_name` directly and updating error handling.
> 
> **CI workflow rename and test job**
> 
> - Rename workflow and job from `build` to `test` in `.github/workflows/test.yml`.
> - Run a matrix on `ubuntu`, `macOS`, and `windows` and add a basic spacectl smoke test (`spacectl --version`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fee35c848f60df3bd453247c3e6e9d5429d42e3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->